### PR TITLE
feat: 카카오 로그인 구현 및 JWT 인증인가 처리

### DIFF
--- a/src/main/java/com/kangwon/festival/domain/security/dto/CustomUserDetails.java
+++ b/src/main/java/com/kangwon/festival/domain/security/dto/CustomUserDetails.java
@@ -1,0 +1,59 @@
+package com.kangwon.festival.domain.security.dto;
+
+import com.kangwon.festival.domain.user.entity.User;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("USER"));
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getNickname();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public Integer getId() {
+        return user.getId();
+    }
+}

--- a/src/main/java/com/kangwon/festival/domain/security/dto/Token.java
+++ b/src/main/java/com/kangwon/festival/domain/security/dto/Token.java
@@ -3,9 +3,7 @@ package com.kangwon.festival.domain.security.dto;
 import org.hibernate.validator.constraints.Length;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
-import lombok.Getter;
 
-@Getter
 @Builder
 public record Token(
         @NotNull @Length(max = 500) String accessToken,

--- a/src/main/java/com/kangwon/festival/domain/security/dto/Token.java
+++ b/src/main/java/com/kangwon/festival/domain/security/dto/Token.java
@@ -1,4 +1,4 @@
-package com.kangwon.festival.domain.user.dto;
+package com.kangwon.festival.domain.security.dto;
 
 import org.hibernate.validator.constraints.Length;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/kangwon/festival/domain/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kangwon/festival/domain/security/jwt/JwtAuthenticationFilter.java
@@ -3,8 +3,12 @@ package com.kangwon.festival.domain.security.jwt;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.util.StringUtils.hasText;
 
+import com.kangwon.festival.domain.security.dto.CustomUserDetails;
 import com.kangwon.festival.domain.user.entity.Role;
+import com.kangwon.festival.domain.user.entity.User;
 import com.kangwon.festival.domain.user.exception.CustomJwtAuthenticationEntryPoint;
+import com.kangwon.festival.domain.user.exception.NotFoundUserException;
+import com.kangwon.festival.domain.user.respository.UserRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -14,6 +18,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -29,6 +34,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final String BLANK = "";
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomJwtAuthenticationEntryPoint authenticationEntryPoint;
+    private final UserRepository userRepository;
 
 
     /**
@@ -50,12 +56,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 jwtTokenProvider.validateToken(token);
 
                 long userId = getUserId(token);
-
                 Role role = getRole(token);
-                List<SimpleGrantedAuthority> authorities =
-                        List.of(new SimpleGrantedAuthority(role.name()));
 
-                val authentication = new UserAuthentication(userId, null, authorities);
+                User user = userRepository.findById(userId)
+                        .orElseThrow(() -> new NotFoundUserException());
+
+                CustomUserDetails principal = new CustomUserDetails(user);
+                List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(role.name()));
+
+                var authentication = new UsernamePasswordAuthenticationToken(principal, null, authorities);
                 authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }

--- a/src/main/java/com/kangwon/festival/domain/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kangwon/festival/domain/security/jwt/JwtAuthenticationFilter.java
@@ -1,4 +1,4 @@
-package com.kangwon.festival.domain.user.jwt;
+package com.kangwon.festival.domain.security.jwt;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.util.StringUtils.hasText;

--- a/src/main/java/com/kangwon/festival/domain/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/kangwon/festival/domain/security/jwt/JwtTokenProvider.java
@@ -1,4 +1,4 @@
-package com.kangwon.festival.domain.user.jwt;
+package com.kangwon.festival.domain.security.jwt;
 
 import com.kangwon.festival.domain.user.entity.Role;
 import com.kangwon.festival.domain.user.exception.ExpiredTokenException;

--- a/src/main/java/com/kangwon/festival/domain/security/jwt/UserAuthentication.java
+++ b/src/main/java/com/kangwon/festival/domain/security/jwt/UserAuthentication.java
@@ -1,4 +1,4 @@
-package com.kangwon.festival.domain.user.jwt;
+package com.kangwon.festival.domain.security.jwt;
 
 import java.util.Collection;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;

--- a/src/main/java/com/kangwon/festival/domain/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/kangwon/festival/domain/security/service/CustomUserDetailsService.java
@@ -1,0 +1,31 @@
+package com.kangwon.festival.domain.security.service;
+
+import com.kangwon.festival.domain.security.dto.CustomUserDetails;
+import com.kangwon.festival.domain.user.entity.User;
+import com.kangwon.festival.domain.user.respository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Autowired
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        User userData = userRepository.findById(Long.valueOf(userId)).orElse(null);
+        if(userData == null){
+            throw new UsernameNotFoundException("User not found with userId: " + userId);
+        }
+        return new CustomUserDetails(userData);
+    }
+
+}

--- a/src/main/java/com/kangwon/festival/domain/user/controller/AuthController.java
+++ b/src/main/java/com/kangwon/festival/domain/user/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.kangwon.festival.domain.user.controller;
 
 import com.kangwon.festival.domain.security.dto.CustomUserDetails;
+import com.kangwon.festival.domain.user.dto.SignInRequest;
 import com.kangwon.festival.domain.user.dto.SignInResponse;
 import com.kangwon.festival.domain.user.service.AuthService;
 import com.kangwon.festival.domain.user.service.KakaoOAuthClient;
@@ -8,11 +9,13 @@ import com.kangwon.festival.global.annotation.CurrentUser;
 import com.kangwon.festival.global.annotation.UserOnly;
 import com.kangwon.festival.global.dto.ApiResponseData;
 import com.kangwon.festival.global.dto.ApiResponseMessage;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -26,9 +29,8 @@ public class AuthController {
     private final KakaoOAuthClient kakaoOAuthClient;
 
     @PostMapping("/login")
-    public ResponseEntity<ApiResponseData> exchange(@RequestParam("code") String code) {
-        String kakaoAccessToken = kakaoOAuthClient.exchangeCodeForAccessToken(code);
-        SignInResponse response = authService.signIn(kakaoAccessToken);
+    public ResponseEntity<ApiResponseData> exchange(@Valid @RequestBody SignInRequest request) {
+        SignInResponse response = authService.signIn(request);
 
         return ResponseEntity.ok()
                 .header("X-Access-Token",  response.accessToken())

--- a/src/main/java/com/kangwon/festival/domain/user/controller/AuthController.java
+++ b/src/main/java/com/kangwon/festival/domain/user/controller/AuthController.java
@@ -1,8 +1,10 @@
 package com.kangwon.festival.domain.user.controller;
 
-import com.kangwon.festival.domain.user.dto.response.SignInResponse;
+import com.kangwon.festival.domain.security.dto.CustomUserDetails;
+import com.kangwon.festival.domain.user.dto.SignInResponse;
 import com.kangwon.festival.domain.user.service.AuthService;
 import com.kangwon.festival.domain.user.service.KakaoOAuthClient;
+import com.kangwon.festival.global.annotation.CurrentUser;
 import com.kangwon.festival.global.annotation.UserOnly;
 import com.kangwon.festival.global.dto.ApiResponseData;
 import com.kangwon.festival.global.dto.ApiResponseMessage;
@@ -37,17 +39,15 @@ public class AuthController {
 
     @UserOnly
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponseMessage> signOut(Authentication authentication) {
-        Long userId = (Long) authentication.getPrincipal();
-        authService.signOut(userId);
+    public ResponseEntity<ApiResponseMessage> signOut(@CurrentUser CustomUserDetails user) {
+        authService.signOut(user);
         return ResponseEntity.ok(ApiResponseMessage.of("로그아웃에 성공하였습니다."));
     }
 
     @UserOnly
     @DeleteMapping
-    public ResponseEntity<ApiResponseMessage> withdraw(Authentication authentication) {
-        Long userId = (Long) authentication.getPrincipal();
-        authService.withdraw(userId);
+    public ResponseEntity<ApiResponseMessage> withdraw(@CurrentUser CustomUserDetails user) {
+        authService.withdraw(user);
         return ResponseEntity.ok(ApiResponseMessage.of("회원이 탈퇴되었습니다."));
     }
 

--- a/src/main/java/com/kangwon/festival/domain/user/dto/KaKaoUserResponse.java
+++ b/src/main/java/com/kangwon/festival/domain/user/dto/KaKaoUserResponse.java
@@ -1,4 +1,4 @@
-package com.kangwon.festival.domain.user.dto.response;
+package com.kangwon.festival.domain.user.dto;
 
 import com.kangwon.festival.domain.user.entity.User;
 import lombok.Builder;

--- a/src/main/java/com/kangwon/festival/domain/user/dto/SignInRequest.java
+++ b/src/main/java/com/kangwon/festival/domain/user/dto/SignInRequest.java
@@ -1,0 +1,21 @@
+package com.kangwon.festival.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+@Builder
+public record SignInRequest(
+        @NotBlank(message = "인가 코드는 필수 값입니다.")
+        String code,
+
+        @NotBlank(message = "닉네임은 필수 입력값입니다.", groups = ValidationGroups.SignUp.class)
+        @Size(max = 50, message = "닉네임은 50자 이하여야 합니다.", groups = ValidationGroups.SignUp.class)
+        String nickname,
+
+        @NotBlank(message = "전화번호는 필수 입력값입니다.", groups = ValidationGroups.SignUp.class)
+        @Pattern(regexp = "^01[0-9]{8,9}$", message = "전화번호 형식이 올바르지 않습니다. 예) 01012345678", groups = ValidationGroups.SignUp.class)
+        String phone    
+) {
+}

--- a/src/main/java/com/kangwon/festival/domain/user/dto/SignInResponse.java
+++ b/src/main/java/com/kangwon/festival/domain/user/dto/SignInResponse.java
@@ -1,6 +1,6 @@
-package com.kangwon.festival.domain.user.dto.response;
+package com.kangwon.festival.domain.user.dto;
 
-import com.kangwon.festival.domain.user.dto.Token;
+import com.kangwon.festival.domain.security.dto.Token;
 import lombok.Builder;
 import lombok.NonNull;
 

--- a/src/main/java/com/kangwon/festival/domain/user/dto/SignInResponse.java
+++ b/src/main/java/com/kangwon/festival/domain/user/dto/SignInResponse.java
@@ -11,8 +11,8 @@ public record SignInResponse(
 ) {
     public static SignInResponse of(Token token) {
         return SignInResponse.builder()
-                .accessToken(token.getAccessToken())
-                .refreshToken(token.getRefreshToken())
+                .accessToken(token.accessToken())
+                .refreshToken(token.refreshToken())
                 .build();
     }
 }

--- a/src/main/java/com/kangwon/festival/domain/user/dto/Token.java
+++ b/src/main/java/com/kangwon/festival/domain/user/dto/Token.java
@@ -1,16 +1,15 @@
 package com.kangwon.festival.domain.user.dto;
 
-import jakarta.persistence.Column;
+import org.hibernate.validator.constraints.Length;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
-public class Token {
-    @Column(nullable = false, length = 500)
-    private String accessToken;
-
-    @Column(nullable = false, length = 500)
-    private String refreshToken;
+public record Token(
+        @NotNull @Length(max = 500) String accessToken,
+        @NotNull @Length(max = 500) String refreshToken
+) {
 }
 

--- a/src/main/java/com/kangwon/festival/domain/user/dto/ValidationGroups.java
+++ b/src/main/java/com/kangwon/festival/domain/user/dto/ValidationGroups.java
@@ -1,0 +1,5 @@
+package com.kangwon.festival.domain.user.dto;
+
+public interface ValidationGroups {
+    interface SignUp {}
+}

--- a/src/main/java/com/kangwon/festival/domain/user/dto/response/KaKaoUserResponse.java
+++ b/src/main/java/com/kangwon/festival/domain/user/dto/response/KaKaoUserResponse.java
@@ -1,0 +1,18 @@
+package com.kangwon.festival.domain.user.dto.response;
+
+import com.kangwon.festival.domain.user.entity.User;
+import lombok.Builder;
+
+@Builder
+public record KaKaoUserResponse (
+        String id,
+        String profileImgUrl
+)
+{
+    public static KaKaoUserResponse of(User user) {
+        return KaKaoUserResponse.builder()
+                .id(user.getKakaoId())
+                .profileImgUrl(user.getProfileImgUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/kangwon/festival/domain/user/entity/User.java
+++ b/src/main/java/com/kangwon/festival/domain/user/entity/User.java
@@ -28,7 +28,7 @@ public class User extends BaseTime {
     private String username;
 
     @Builder
-    public User(String kakaoId, String nickname, String profileImgUrl) {
+    public User(String kakaoId, String profileImgUrl) {
         this.kakaoId = kakaoId;
         this.profileImgUrl = profileImgUrl;
     }

--- a/src/main/java/com/kangwon/festival/domain/user/entity/User.java
+++ b/src/main/java/com/kangwon/festival/domain/user/entity/User.java
@@ -22,13 +22,15 @@ public class User extends BaseTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
     private String kakaoId;
-    private String nickname;
     private String refreshToken;
+    private String profileImgUrl;
+    private String phone;
+    private String username;
 
     @Builder
-    public User(String kakaoId, String nickname) {
+    public User(String kakaoId, String nickname, String profileImgUrl) {
         this.kakaoId = kakaoId;
-        this.nickname = nickname;
+        this.profileImgUrl = profileImgUrl;
     }
 
     public void updateRefreshToken(String refreshToken) {

--- a/src/main/java/com/kangwon/festival/domain/user/entity/User.java
+++ b/src/main/java/com/kangwon/festival/domain/user/entity/User.java
@@ -25,12 +25,14 @@ public class User extends BaseTime {
     private String refreshToken;
     private String profileImgUrl;
     private String phone;
-    private String username;
+    private String nickname;
 
     @Builder
-    public User(String kakaoId, String profileImgUrl) {
+    public User(String kakaoId, String profileImgUrl, String phone, String nickname) {
         this.kakaoId = kakaoId;
         this.profileImgUrl = profileImgUrl;
+        this.phone = phone;
+        this.nickname = nickname;
     }
 
     public void updateRefreshToken(String refreshToken) {

--- a/src/main/java/com/kangwon/festival/domain/user/exception/DuplicateNicknameException.java
+++ b/src/main/java/com/kangwon/festival/domain/user/exception/DuplicateNicknameException.java
@@ -1,0 +1,11 @@
+package com.kangwon.festival.domain.user.exception;
+
+import static com.kangwon.festival.global.exception.Code.DUPLICATE_NICKNAME;
+
+import com.kangwon.festival.global.exception.BaseException;
+
+public class DuplicateNicknameException extends BaseException {
+    public DuplicateNicknameException() {
+        super(DUPLICATE_NICKNAME);
+    }
+}

--- a/src/main/java/com/kangwon/festival/domain/user/respository/UserRepository.java
+++ b/src/main/java/com/kangwon/festival/domain/user/respository/UserRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByKakaoId(String kakaoId);
+    boolean existsByKakaoId(String kakaoId);
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/kangwon/festival/domain/user/service/AuthService.java
+++ b/src/main/java/com/kangwon/festival/domain/user/service/AuthService.java
@@ -1,16 +1,18 @@
 package com.kangwon.festival.domain.user.service;
 
-import com.kangwon.festival.domain.user.dto.response.KaKaoUserResponse;
-import com.kangwon.festival.domain.user.dto.response.SignInResponse;
-import com.kangwon.festival.domain.user.dto.Token;
+import com.kangwon.festival.domain.security.dto.CustomUserDetails;
+import com.kangwon.festival.domain.user.dto.KaKaoUserResponse;
+import com.kangwon.festival.domain.user.dto.SignInResponse;
+import com.kangwon.festival.domain.security.dto.Token;
 import com.kangwon.festival.domain.user.entity.User;
 import com.kangwon.festival.domain.user.exception.InValidTokenException;
 import com.kangwon.festival.domain.user.exception.NotFoundUserException;
-import com.kangwon.festival.domain.user.jwt.JwtTokenProvider;
-import com.kangwon.festival.domain.user.jwt.UserAuthentication;
+import com.kangwon.festival.domain.security.jwt.JwtTokenProvider;
+import com.kangwon.festival.domain.security.jwt.UserAuthentication;
 import com.kangwon.festival.domain.user.respository.UserRepository;
 import com.kangwon.festival.global.annotation.MethodDescription;
 import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -37,15 +39,15 @@ public class AuthService {
 
     @MethodDescription(description = "로그아웃을 진행합니다.")
     @Transactional
-    public void signOut(long userId) {
-        User user = findUser(userId);
+    public void signOut(CustomUserDetails customUserDetails) {
+        User user = findUser(customUserDetails);
         user.resetRefreshToken();
     }
 
     @MethodDescription(description = "회원을 탈퇴합니다.")
     @Transactional
-    public void withdraw(long userId) {
-        User user = findUser(userId);
+    public void withdraw(CustomUserDetails customUserDetails) {
+        User user = findUser(customUserDetails);
         deleteUser(user);
     }
 
@@ -61,7 +63,7 @@ public class AuthService {
         if (!Objects.equals(saved, refreshToken)) throw new InValidTokenException("유효하지 않은 리프레시 토큰입니다.");
 
 
-        Token token = generatetoken(new UserAuthentication(user.getId(), null, null));
+        Token token = generateToken(new UserAuthentication(user.getId(), null, null));
         user.updateRefreshToken(token.getRefreshToken());
 
         return SignInResponse.of(token);
@@ -90,21 +92,28 @@ public class AuthService {
 
     @MethodDescription(description = "토큰을 발급받습니다.")
     private Token getToken(User user) {
-        Token token = generatetoken(new UserAuthentication(user.getId(), null, null));
+        Token token = generateToken(new UserAuthentication(user.getId(), null, null));
         user.updateRefreshToken(token.getRefreshToken());
         return token;
     }
 
     @MethodDescription(description = "토큰을 발급받습니다.")
-    private Token generatetoken(Authentication authentication) {
+    private Token generateToken(Authentication authentication) {
         return Token.builder()
                 .accessToken(jwtTokenProvider.generateToken(authentication, ACCESS_TOKEN_EXPIRATION))
                 .refreshToken(jwtTokenProvider.generateToken(authentication, REFRESH_TOKEN_EXPIRATION))
                 .build();
     }
 
-    @MethodDescription(description = "유저를 조회합니다.")
-    private User findUser(long userId) {
+    @MethodDescription(description = "유저를 조회합니다. (SecurityContext 기반)")
+    private User findUser(CustomUserDetails principal) {
+        return Optional.ofNullable(principal)
+                .map(CustomUserDetails::getUser)
+                .orElseThrow(NotFoundUserException::new);
+    }
+
+    @MethodDescription(description = "유저를 조회합니다. (PK 기반)")
+    private User findUser(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(NotFoundUserException::new);
     }

--- a/src/main/java/com/kangwon/festival/domain/user/service/AuthService.java
+++ b/src/main/java/com/kangwon/festival/domain/user/service/AuthService.java
@@ -2,17 +2,24 @@ package com.kangwon.festival.domain.user.service;
 
 import com.kangwon.festival.domain.security.dto.CustomUserDetails;
 import com.kangwon.festival.domain.user.dto.KaKaoUserResponse;
+import com.kangwon.festival.domain.user.dto.SignInRequest;
 import com.kangwon.festival.domain.user.dto.SignInResponse;
 import com.kangwon.festival.domain.security.dto.Token;
+import com.kangwon.festival.domain.user.dto.ValidationGroups;
 import com.kangwon.festival.domain.user.entity.User;
+import com.kangwon.festival.domain.user.exception.DuplicateNicknameException;
 import com.kangwon.festival.domain.user.exception.InValidTokenException;
 import com.kangwon.festival.domain.user.exception.NotFoundUserException;
 import com.kangwon.festival.domain.security.jwt.JwtTokenProvider;
 import com.kangwon.festival.domain.security.jwt.UserAuthentication;
 import com.kangwon.festival.domain.user.respository.UserRepository;
 import com.kangwon.festival.global.annotation.MethodDescription;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -28,13 +35,27 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
     private final KakaoService kakaoService;
+    private final KakaoOAuthClient kakaoOAuthClient;
+    private final Validator validator;
 
-    @MethodDescription(description = "로그인을 진행합니다.")
+    @MethodDescription(description = "로그인/회원가입(신규 시만 닉네임·전화번호 검증 및 저장)")
     @Transactional
-    public SignInResponse signIn(String kakaoAccessToken) {
-        User user = getUser(kakaoAccessToken);
+    public SignInResponse signIn(SignInRequest request) {
+        String kakaoAccessToken = kakaoOAuthClient.exchangeCodeForAccessToken(request.code());
+        KaKaoUserResponse kakao = kakaoService.getKakaoData(kakaoAccessToken);
+        boolean isNew = !userRepository.existsByKakaoId(kakao.id());
+
+        if (isNew) validateForSignUp(request);
+
+        User user = getUser(kakaoAccessToken, request);
         Token token = getToken(user);
         return SignInResponse.of(token);
+    }
+
+    @MethodDescription(description = "신규 가입 검증(그룹)")
+    private void validateForSignUp(SignInRequest req) {
+        Set<ConstraintViolation<SignInRequest>> v = validator.validate(req, ValidationGroups.SignUp.class);
+        if (!v.isEmpty()) throw new ConstraintViolationException(v);
     }
 
     @MethodDescription(description = "로그아웃을 진행합니다.")
@@ -70,21 +91,28 @@ public class AuthService {
     }
 
     @MethodDescription(description = "Kakao에서 유저 정보를 조회합니다.")
-    private User getUser(String kakaoAccessToken) {
+    private User getUser(String kakaoAccessToken, SignInRequest request) {
         KaKaoUserResponse kakao = kakaoService.getKakaoData(kakaoAccessToken);
-        return signUp(kakao);
+        return signUp(kakao, request);
     }
 
     @MethodDescription(description = "KakaoId를 조회합니다. 조회된 Id가 없는 경우 새롭게 가입을 진행합니다.")
-    private User signUp(KaKaoUserResponse kakao) {
-        return userRepository.findByKakaoId(kakao.id()).
-                orElseGet(() -> saveUser(kakao));
+    private User signUp(KaKaoUserResponse kakao, SignInRequest request) {
+        return userRepository.findByKakaoId(kakao.id())
+                .orElseGet(() -> {
+                    if (userRepository.existsByNickname(request.nickname())) {
+                        throw new DuplicateNicknameException();
+                    }
+                    return saveUser(kakao, request);
+                });
     }
 
     @MethodDescription(description = "유저를 저장합니다.")
-    private User saveUser(KaKaoUserResponse kakao) {
+    private User saveUser(KaKaoUserResponse kakao, SignInRequest request) {
         User user = User.builder()
                 .kakaoId(kakao.id())
+                .nickname(request.nickname())
+                .phone(request.phone())
                 .profileImgUrl(kakao.profileImgUrl())
                 .build();
         return userRepository.save(user);

--- a/src/main/java/com/kangwon/festival/domain/user/service/AuthService.java
+++ b/src/main/java/com/kangwon/festival/domain/user/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.kangwon.festival.domain.user.service;
 
+import com.kangwon.festival.domain.user.dto.response.KaKaoUserResponse;
 import com.kangwon.festival.domain.user.dto.response.SignInResponse;
 import com.kangwon.festival.domain.user.dto.Token;
 import com.kangwon.festival.domain.user.entity.User;
@@ -68,20 +69,21 @@ public class AuthService {
 
     @MethodDescription(description = "Kakao에서 유저 정보를 조회합니다.")
     private User getUser(String kakaoAccessToken) {
-        String kakaoId = kakaoService.getKakaoData(kakaoAccessToken);
-        return signUp(kakaoId);
+        KaKaoUserResponse kakao = kakaoService.getKakaoData(kakaoAccessToken);
+        return signUp(kakao);
     }
 
     @MethodDescription(description = "KakaoId를 조회합니다. 조회된 Id가 없는 경우 새롭게 가입을 진행합니다.")
-    private User signUp(String kakaoId) {
-        return userRepository.findByKakaoId(kakaoId).
-                orElseGet(() -> saveUser(kakaoId));
+    private User signUp(KaKaoUserResponse kakao) {
+        return userRepository.findByKakaoId(kakao.id()).
+                orElseGet(() -> saveUser(kakao));
     }
 
     @MethodDescription(description = "유저를 저장합니다.")
-    private User saveUser(String kakaoId) {
+    private User saveUser(KaKaoUserResponse kakao) {
         User user = User.builder()
-                .kakaoId(kakaoId)
+                .kakaoId(kakao.id())
+                .profileImgUrl(kakao.profileImgUrl())
                 .build();
         return userRepository.save(user);
     }

--- a/src/main/java/com/kangwon/festival/domain/user/service/AuthService.java
+++ b/src/main/java/com/kangwon/festival/domain/user/service/AuthService.java
@@ -64,7 +64,7 @@ public class AuthService {
 
 
         Token token = generateToken(new UserAuthentication(user.getId(), null, null));
-        user.updateRefreshToken(token.getRefreshToken());
+        user.updateRefreshToken(token.refreshToken());
 
         return SignInResponse.of(token);
     }
@@ -93,7 +93,7 @@ public class AuthService {
     @MethodDescription(description = "토큰을 발급받습니다.")
     private Token getToken(User user) {
         Token token = generateToken(new UserAuthentication(user.getId(), null, null));
-        user.updateRefreshToken(token.getRefreshToken());
+        user.updateRefreshToken(token.refreshToken());
         return token;
     }
 

--- a/src/main/java/com/kangwon/festival/domain/user/service/KakaoService.java
+++ b/src/main/java/com/kangwon/festival/domain/user/service/KakaoService.java
@@ -36,7 +36,6 @@ public class KakaoService {
 
             Map<String, Object> properties = (Map<String, Object>) body.get("properties");
             String profileImgUrl = properties != null ? (String) properties.get("profile_image") : null;
-            String profileImgUrl = properties != null ? (String) properties.get("profile_image") : null;
 
             return KaKaoUserResponse.builder()
                     .id(id)

--- a/src/main/java/com/kangwon/festival/domain/user/service/KakaoService.java
+++ b/src/main/java/com/kangwon/festival/domain/user/service/KakaoService.java
@@ -1,6 +1,7 @@
 package com.kangwon.festival.domain.user.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kangwon.festival.domain.user.dto.response.KaKaoUserResponse;
 import com.kangwon.festival.global.annotation.MethodDescription;
 import com.kangwon.festival.global.exception.InternalServerException;
 import org.springframework.http.HttpEntity;
@@ -10,7 +11,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
-import com.google.gson.JsonArray;
 
 import java.util.Map;
 
@@ -22,13 +22,25 @@ public class KakaoService {
     private static final String KAKAO_ME_URL = "https://kapi.kakao.com/v2/user/me";
 
     @MethodDescription(description = "카카오에서 유저 정보를 가져옵니다.")
-    public String getKakaoData(String kakaoAccessToken) {
+    public KaKaoUserResponse getKakaoData(String kakaoAccessToken) {
         try{
             HttpHeaders headers = new HttpHeaders();
             headers.add("Authorization", "Bearer " + kakaoAccessToken);
-            HttpEntity httpEntity = new HttpEntity<JsonArray>(headers);
-            ResponseEntity<Object> responseData = restTemplate.exchange(KAKAO_ME_URL, HttpMethod.GET, httpEntity, Object.class);
-            return objectMapper.convertValue(responseData.getBody(), Map.class).get("id").toString();
+            HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+            ResponseEntity<Object> responseData =
+                    restTemplate.exchange(KAKAO_ME_URL, HttpMethod.GET, httpEntity, Object.class);
+
+            Map<String, Object> body = objectMapper.convertValue(responseData.getBody(), Map.class);
+
+            String id = body.get("id").toString();
+
+            Map<String, Object> properties = (Map<String, Object>) body.get("properties");
+            String profileImgUrl = properties != null ? (String) properties.get("profile_image") : null;
+
+            return KaKaoUserResponse.builder()
+                    .id(id)
+                    .profileImgUrl(profileImgUrl)
+                    .build();
         } catch (Exception e) {
             throw new InternalServerException();
         }

--- a/src/main/java/com/kangwon/festival/domain/user/service/KakaoService.java
+++ b/src/main/java/com/kangwon/festival/domain/user/service/KakaoService.java
@@ -1,7 +1,7 @@
 package com.kangwon.festival.domain.user.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.kangwon.festival.domain.user.dto.response.KaKaoUserResponse;
+import com.kangwon.festival.domain.user.dto.KaKaoUserResponse;
 import com.kangwon.festival.global.annotation.MethodDescription;
 import com.kangwon.festival.global.exception.InternalServerException;
 import org.springframework.http.HttpEntity;
@@ -35,6 +35,7 @@ public class KakaoService {
             String id = body.get("id").toString();
 
             Map<String, Object> properties = (Map<String, Object>) body.get("properties");
+            String profileImgUrl = properties != null ? (String) properties.get("profile_image") : null;
             String profileImgUrl = properties != null ? (String) properties.get("profile_image") : null;
 
             return KaKaoUserResponse.builder()

--- a/src/main/java/com/kangwon/festival/global/annotation/CurrentUser.java
+++ b/src/main/java/com/kangwon/festival/global/annotation/CurrentUser.java
@@ -1,0 +1,14 @@
+package com.kangwon.festival.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal
+public @interface CurrentUser {
+}
+

--- a/src/main/java/com/kangwon/festival/global/config/SecurityConfig.java
+++ b/src/main/java/com/kangwon/festival/global/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.kangwon.festival.global.config;
 
-import com.kangwon.festival.domain.security.service.CustomUserDetailsService;
 import com.kangwon.festival.domain.user.exception.CustomAccessDeniedHandler;
 import com.kangwon.festival.domain.user.exception.CustomJwtAuthenticationEntryPoint;
 import com.kangwon.festival.domain.security.jwt.JwtAuthenticationFilter;
@@ -24,7 +23,6 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
-    private final CustomUserDetailsService customUserDetailsService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/com/kangwon/festival/global/config/SecurityConfig.java
+++ b/src/main/java/com/kangwon/festival/global/config/SecurityConfig.java
@@ -1,8 +1,9 @@
 package com.kangwon.festival.global.config;
 
+import com.kangwon.festival.domain.security.service.CustomUserDetailsService;
 import com.kangwon.festival.domain.user.exception.CustomAccessDeniedHandler;
 import com.kangwon.festival.domain.user.exception.CustomJwtAuthenticationEntryPoint;
-import com.kangwon.festival.domain.user.jwt.JwtAuthenticationFilter;
+import com.kangwon.festival.domain.security.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,6 +24,7 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final CustomUserDetailsService customUserDetailsService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/com/kangwon/festival/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kangwon/festival/global/exception/GlobalExceptionHandler.java
@@ -61,5 +61,20 @@ public class GlobalExceptionHandler {
         ApiResponseError response = ApiResponseError.of(code, message);
         return ResponseEntity.status(code.getStatus()).body(response);
     }
+
+    @MethodDescription(description = "프로그램적 검증 및 @Validated 파라미터의 제약 위반 처리")
+    @ExceptionHandler(jakarta.validation.ConstraintViolationException.class)
+    public ResponseEntity<ApiResponseError> handleConstraintViolation(jakarta.validation.ConstraintViolationException e) {
+        log.warn("[ConstraintViolationException] {}: {}", e.getClass().getName(), e.getMessage());
+
+        String message = e.getConstraintViolations().stream()
+                .map(v -> v.getMessage())
+                .distinct()
+                .collect(java.util.stream.Collectors.joining(", "));
+
+        ApiResponseError response = ApiResponseError.of(Code.VALIDATION_ERROR, message);
+        return ResponseEntity.status(Code.VALIDATION_ERROR.getStatus()).body(response);
+    }
+
 }
 


### PR DESCRIPTION
[JWT권한추가](https://github.com/KNU-Festival-Project-2025/KNU_Festival_Backend/issues/13)

- JWT 인증 필터 도입: CustomUserDetails 설정 및 @CurrentUser 사용 지원
- 컨트롤러 단에서 매번 토큰 파싱 없이 현재 로그인 사용자 정보 접근